### PR TITLE
A Spring starter for oracle nosql

### DIFF
--- a/spring-cloud-oci/docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-oci/docs/src/main/asciidoc/index.adoc
@@ -30,6 +30,8 @@ include::storage.adoc[]
 
 include::notifications.adoc[]
 
+include::nosql.adoc[]
+
 include::queues.adoc[]
 
 include::streaming.adoc[]

--- a/spring-cloud-oci/docs/src/main/asciidoc/nosql.adoc
+++ b/spring-cloud-oci/docs/src/main/asciidoc/nosql.adoc
@@ -1,0 +1,97 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+
+[#oci-nosql]
+== Oracle NoSQL Database
+
+https://docs.oracle.com/en-us/iaas/nosql-database/index.html[Oracle NoSQL Database] service offering on-demand throughput and storage based provisioning that supports JSON, Table and Key-Value datatypes, all with flexible transaction guarantees.
+
+Maven coordinates:
+
+[source,xml]
+----
+<dependency>
+    <groupId>com.oracle.cloud.spring</groupId>
+    <artifactId>spring-cloud-oci-starter-nosql</artifactId>
+</dependency>
+----
+
+Gradle coordinates:
+
+[source,subs="normal"]
+----
+dependencies {
+    implementation("com.oracle.cloud.spring:spring-cloud-oci-starter-nosql")
+}
+----
+
+=== Using Oracle NoSQL Database
+
+The starter automatically configures and registers a `NosqlDBConfig` bean in the Spring application, allowing the use of Oracle NoSQL Database repositories.
+
+[source,yaml]
+----
+spring:
+  cloud:
+    oci:
+      config:
+        type: file
+      region:
+        static: us-ashburn-1
+----
+
+Enable NoSQL repositories in your application by using the `@EnableNosqlRepositories` annotation and extending the `AbstractNosqlConfiguration` class.
+
+[source,java]
+----
+import com.oracle.nosql.spring.data.config.AbstractNosqlConfiguration;
+import com.oracle.nosql.spring.data.repository.config.EnableNosqlRepositories;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+@EnableNosqlRepositories
+public class MyApp extends AbstractNosqlConfiguration {
+    public static void main(String[] args) {
+        SpringApplication.run(MyApp.class, args);
+    }
+}
+----
+
+NoSQL repositories and tables are simply defined by extending the `NosqlRepository` interface and applying the `@NosqlTable` annotation:
+
+[source,java]
+----
+public interface BookRepository extends NosqlRepository<Book, Long> {
+    // Add repository methods as needed.
+    Iterable<Book> findByAuthor(String author);
+    Iterable<Book> findByTitle(String title);
+}
+----
+
+[source,java]
+----
+@NosqlTable(tableName = "books")
+public class Book {
+    @NosqlId(generated = true)
+    long id;
+    String title;
+    String author;
+    double price;
+}
+----
+
+
+=== Configuration
+
+The Spring Boot Starter for Oracle Cloud NoSQL Database provides the following configuration options:
+
+|===
+^| Name ^| Description ^| Required ^| Default value
+| `spring.cloud.oci.nosql.enabled` | Enables the NoSQL DB Config. | No | `true`
+|===
+
+
+=== Sample
+
+A sample application provided https://github.com/oracle/spring-cloud-oracle/tree/main/spring-cloud-oci/spring-cloud-oci-samples/spring-cloud-oci-nosql-sample[here] contains the examples to demonstrates the usage of OCI Spring Cloud NoSQL module.

--- a/spring-cloud-oci/pom.xml
+++ b/spring-cloud-oci/pom.xml
@@ -75,6 +75,8 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
         <spring-cloud-oci-dependencies.version>${project.version}</spring-cloud-oci-dependencies.version>
         <spring-cloud-dependencies.version>2023.0.2</spring-cloud-dependencies.version>
         <spring-framework.version>6.1.10</spring-framework.version>
+        <spring-data-oracle-nosql.version>2.0.0</spring-data-oracle-nosql.version>
+        <oracle.nosql.driver.version>5.4.15</oracle.nosql.driver.version>
         <jakarta-mail.version>2.0.3</jakarta-mail.version>
         <oci-sdk.version>3.44.3</oci-sdk.version>
         <maven.compiler.source>17</maven.compiler.source>
@@ -171,6 +173,46 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
                 <artifactId>spring-context-support</artifactId>
                 <version>${spring-framework.version}</version>
                 <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.oracle.nosql.sdk</groupId>
+                <artifactId>spring-data-oracle-nosql</artifactId>
+                <version>${spring-data-oracle-nosql.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.oracle.nosql.sdk</groupId>
+                <artifactId>nosqldriver</artifactId>
+                <version>${oracle.nosql.driver.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.data</groupId>
+                <artifactId>spring-data-commons</artifactId>
+                <version>${spring-boot.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-core</artifactId>
+                <version>${spring-framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-tx</artifactId>
+                <version>${spring-framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-expression</artifactId>
+                <version>${spring-framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-beans</artifactId>
+                <version>${spring-framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-context</artifactId>
+                <version>${spring-framework.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.angus</groupId>

--- a/spring-cloud-oci/spring-cloud-oci-autoconfigure/pom.xml
+++ b/spring-cloud-oci/spring-cloud-oci-autoconfigure/pom.xml
@@ -101,6 +101,11 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>com.oracle.nosql.sdk</groupId>
+            <artifactId>spring-data-oracle-nosql</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>com.oracle.cloud.spring</groupId>
             <artifactId>spring-cloud-oci-function</artifactId>
             <optional>true</optional>

--- a/spring-cloud-oci/spring-cloud-oci-autoconfigure/src/main/java/com/oracle/cloud/spring/nosql/NoSQLAutoConfiguration.java
+++ b/spring-cloud-oci/spring-cloud-oci-autoconfigure/src/main/java/com/oracle/cloud/spring/nosql/NoSQLAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- ** Copyright (c) 2023, Oracle and/or its affiliates.
+ ** Copyright (c) 2024, Oracle and/or its affiliates.
  ** Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
  */
 package com.oracle.cloud.spring.nosql;

--- a/spring-cloud-oci/spring-cloud-oci-autoconfigure/src/main/java/com/oracle/cloud/spring/nosql/NoSQLAutoConfiguration.java
+++ b/spring-cloud-oci/spring-cloud-oci-autoconfigure/src/main/java/com/oracle/cloud/spring/nosql/NoSQLAutoConfiguration.java
@@ -1,0 +1,64 @@
+/*
+ ** Copyright (c) 2023, Oracle and/or its affiliates.
+ ** Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+ */
+package com.oracle.cloud.spring.nosql;
+
+import java.io.IOException;
+
+import com.oracle.bmc.auth.RegionProvider;
+import com.oracle.cloud.spring.autoconfigure.core.CredentialsProperties;
+import com.oracle.nosql.spring.data.config.NosqlDbConfig;
+import oracle.nosql.driver.iam.SignatureProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.context.annotation.Bean;
+
+import static com.oracle.cloud.spring.autoconfigure.core.RegionProviderAutoConfiguration.regionProviderQualifier;
+
+@AutoConfiguration
+@ConditionalOnClass(NosqlDbConfig.class)
+@ConditionalOnProperty(name = "spring.cloud.oci.nosql.enabled", havingValue = "true", matchIfMissing = true)
+public class NoSQLAutoConfiguration {
+    @Bean
+    @RefreshScope
+    @ConditionalOnMissingBean
+    public NosqlDbConfig nosqlDbConfig(@Qualifier(regionProviderQualifier) RegionProvider regionProvider,
+                                       CredentialsProperties properties) throws IOException {
+        String profile = properties.hasProfile() ? properties.getProfile() : "DEFAULT";
+        SignatureProvider signatureProvider;
+        switch (properties.getType()) {
+            case WORKLOAD_IDENTITY -> signatureProvider = SignatureProvider.createWithOkeWorkloadIdentity();
+            case RESOURCE_PRINCIPAL -> signatureProvider = SignatureProvider.createWithResourcePrincipal();
+            case INSTANCE_PRINCIPAL ->
+                    signatureProvider = SignatureProvider.createWithInstancePrincipal();
+            case SIMPLE -> signatureProvider = new SignatureProvider(
+                    properties.getTenantId(),
+                    properties.getUserId(),
+                    properties.getFingerprint(),
+                    properties.getPrivateKey(),
+                    properties.getPassPhrase() != null ? properties.getPassPhrase().toCharArray() : null
+            );
+            case SESSION_TOKEN -> {
+                if (properties.hasFile()) {
+                    signatureProvider = SignatureProvider.createWithSessionToken(properties.getFile(), profile);
+                } else {
+                    signatureProvider = SignatureProvider.createWithSessionToken(profile);
+                }
+            }
+            default -> {
+                if (properties.hasFile()) {
+                    signatureProvider = new SignatureProvider(properties.getFile(), profile);
+                } else {
+                    signatureProvider = new SignatureProvider(profile);
+                }
+
+            }
+        }
+        return new NosqlDbConfig(regionProvider.getRegion().getRegionId(), signatureProvider);
+    }
+}

--- a/spring-cloud-oci/spring-cloud-oci-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-oci/spring-cloud-oci-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -65,6 +65,12 @@
       "type": "java.lang.Boolean",
       "description": "Auto-configure OCI Autonomous Database components.",
       "defaultValue": true
+    },
+    {
+      "name": "spring.cloud.oci.nosql.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Auto-configure Oracle NoSQL Database components.",
+      "defaultValue": true
     }
   ]
 }

--- a/spring-cloud-oci/spring-cloud-oci-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-cloud-oci/spring-cloud-oci-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -11,3 +11,4 @@ com.oracle.cloud.spring.genai.GenAIAutoConfiguration
 com.oracle.cloud.spring.vault.VaultAutoConfiguration
 com.oracle.cloud.spring.adb.AutonomousDbAutoConfiguration
 com.oracle.cloud.spring.email.EmailDeliveryAutoConfiguration
+com.oracle.cloud.spring.nosql.NoSQLAutoConfiguration

--- a/spring-cloud-oci/spring-cloud-oci-autoconfigure/src/test/java/com/oracle/cloud/spring/autoconfigure/TestCommonConfigurationBeans.java
+++ b/spring-cloud-oci/spring-cloud-oci-autoconfigure/src/test/java/com/oracle/cloud/spring/autoconfigure/TestCommonConfigurationBeans.java
@@ -8,16 +8,24 @@ package com.oracle.cloud.spring.autoconfigure;
 import com.oracle.bmc.Region;
 import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
 import com.oracle.bmc.auth.RegionProvider;
+import com.oracle.cloud.spring.autoconfigure.core.CredentialsProperties;
 import com.oracle.cloud.spring.core.compartment.CompartmentProvider;
 import com.oracle.cloud.spring.core.compartment.StaticCompartmentProvider;
 import com.oracle.cloud.spring.core.region.StaticRegionProvider;
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 @Configuration
 public class TestCommonConfigurationBeans {
+    @Bean
+    CredentialsProperties credentialsProperties() {
+        return new CredentialsProperties();
+    }
+
     @Bean
     BasicAuthenticationDetailsProvider credentialsProvider() {
         return mock(BasicAuthenticationDetailsProvider.class);
@@ -31,6 +39,19 @@ public class TestCommonConfigurationBeans {
     @Bean
     CompartmentProvider compartmentProvider() {
         return new StaticCompartmentProvider("compartmentOCID");
+    }
+
+    public static void assertBeanLoaded(AssertableApplicationContext ctx, Class<?> clazz) {
+        assertBeanLoaded(ctx, clazz, true);
+    }
+
+    public static void assertBeanNotLoaded(AssertableApplicationContext ctx, Class<?> clazz) {
+        assertBeanLoaded(ctx, clazz, false);
+    }
+
+    static void assertBeanLoaded(AssertableApplicationContext ctx, Class<?> clazz, boolean loaded) {
+        String[] beans = ctx.getBeanNamesForType(clazz);
+        assertThat(beans).hasSize(loaded ? 2 : 0);
     }
 
 }

--- a/spring-cloud-oci/spring-cloud-oci-autoconfigure/src/test/java/com/oracle/cloud/spring/nosql/NoSQLAutoConfigurationTests.java
+++ b/spring-cloud-oci/spring-cloud-oci-autoconfigure/src/test/java/com/oracle/cloud/spring/nosql/NoSQLAutoConfigurationTests.java
@@ -1,8 +1,9 @@
 // Copyright (c) 2024, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
-package com.oracle.cloud.spring.vault;
+package com.oracle.cloud.spring.nosql;
 
 import com.oracle.cloud.spring.autoconfigure.TestCommonConfigurationBeans;
+import com.oracle.nosql.spring.data.config.NosqlDbConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -10,30 +11,20 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import static com.oracle.cloud.spring.autoconfigure.TestCommonConfigurationBeans.assertBeanLoaded;
 import static com.oracle.cloud.spring.autoconfigure.TestCommonConfigurationBeans.assertBeanNotLoaded;
 
-public class VaultAutoConfigurationTests {
-    private final String vaultIdProperty = "spring.cloud.oci.vault.vault-id=xyz";
+public class NoSQLAutoConfigurationTests {
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-            .withPropertyValues("spring.cloud.oci.vault.enabled=true",
-                    "spring.cloud.oci.vault.compartment=xyz")
-            .withConfiguration(AutoConfigurations.of(VaultAutoConfiguration.class))
+            .withPropertyValues("spring.cloud.oci.nosql.enabled=true")
+            .withConfiguration(AutoConfigurations.of(NoSQLAutoConfiguration.class))
             .withUserConfiguration(TestCommonConfigurationBeans.class);
-
 
     @Test
     void beansAreLoaded() {
-        contextRunner.withPropertyValues(vaultIdProperty)
-                .run(ctx -> assertBeanLoaded(ctx, VaultTemplate.class));
+        contextRunner.run(ctx -> assertBeanLoaded(ctx, NosqlDbConfig.class));
     }
 
     @Test
     void beansAreNotLoadedWhenDisabled() {
-        contextRunner.withPropertyValues(vaultIdProperty,
-                        "spring.cloud.oci.vault.enabled=false")
-                .run(ctx -> assertBeanNotLoaded(ctx, VaultTemplate.class));
-    }
-
-    @Test
-    void beansAreNotLoadedWhenNoVault() {
-        contextRunner.run(ctx -> assertBeanNotLoaded(ctx, VaultTemplate.class));
+        contextRunner.withPropertyValues("spring.cloud.oci.nosql.enabled=false")
+                .run(ctx -> assertBeanNotLoaded(ctx, NosqlDbConfig.class));
     }
 }

--- a/spring-cloud-oci/spring-cloud-oci-dependencies/pom.xml
+++ b/spring-cloud-oci/spring-cloud-oci-dependencies/pom.xml
@@ -157,6 +157,11 @@
                 <artifactId>spring-cloud-oci-starter-email</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.oracle.cloud.spring</groupId>
+                <artifactId>spring-cloud-oci-starter-nosql</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/spring-cloud-oci/spring-cloud-oci-samples/pom.xml
+++ b/spring-cloud-oci/spring-cloud-oci-samples/pom.xml
@@ -50,6 +50,7 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
         <module>spring-cloud-oci-function-sample</module>
         <module>spring-cloud-oci-adb-sample</module>
         <module>spring-cloud-oci-email-sample</module>
+        <module>spring-cloud-oci-nosql-sample</module>
     </modules>
 
     <artifactId>spring-cloud-oci-samples</artifactId>

--- a/spring-cloud-oci/spring-cloud-oci-samples/spring-cloud-oci-nosql-sample/pom.xml
+++ b/spring-cloud-oci/spring-cloud-oci-samples/spring-cloud-oci-nosql-sample/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2024, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<groupId>com.oracle.cloud.spring</groupId>
+		<artifactId>spring-cloud-oci-samples</artifactId>
+		<version>1.3.0-SNAPSHOT</version>
+		</parent>
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.oracle.cloud.spring.sample.nosql</groupId>
+	<artifactId>spring-cloud-oci-nosql-sample</artifactId>
+	<name>spring-cloud-oci-nosql-sample</name>
+	<description>spring-cloud-oci-nosql-sample</description>
+
+	<organization>
+		<name>Oracle America, Inc.</name>
+		<url>https://www.oracle.com</url>
+	</organization>
+
+	<developers>
+		<developer>
+			<name>Oracle</name>
+			<email>obaas_ww at oracle.com</email>
+			<organization>Oracle America, Inc.</organization>
+			<organizationUrl>https://www.oracle.com</organizationUrl>
+		</developer>
+	</developers>
+
+	<licenses>
+		<license>
+			<name>The Universal Permissive License (UPL), Version 1.0</name>
+			<url>https://oss.oracle.com/licenses/upl/</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+
+	<scm>
+		<url>https://github.com/oracle/spring-cloud-oracle</url>
+		<connection>scm:git:https://github.com/oracle/spring-cloud-oracle.git</connection>
+		<developerConnection>scm:git:git@github.com:oracle/spring-cloud-oracle.git</developerConnection>
+	</scm>
+
+	<properties>
+		<java.version>17</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>com.oracle.cloud.spring</groupId>
+			<artifactId>spring-cloud-oci-starter-nosql</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.oracle.cloud.spring.sample.common</groupId>
+			<artifactId>spring-cloud-oci-common-samples-utils</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.oracle.cloud.spring.sample.common</groupId>
+			<artifactId>spring-cloud-oci-common-samples-utils</artifactId>
+			<type>test-jar</type>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+
+</project>

--- a/spring-cloud-oci/spring-cloud-oci-samples/spring-cloud-oci-nosql-sample/src/main/java/com/oracle/cloud/spring/sample/nosql/springcloudnosqlsample/Book.java
+++ b/spring-cloud-oci/spring-cloud-oci-samples/spring-cloud-oci-nosql-sample/src/main/java/com/oracle/cloud/spring/sample/nosql/springcloudnosqlsample/Book.java
@@ -1,0 +1,75 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+package com.oracle.cloud.spring.sample.nosql.springcloudnosqlsample;
+
+import com.oracle.nosql.spring.data.core.mapping.NosqlId;
+import com.oracle.nosql.spring.data.core.mapping.NosqlTable;
+
+// Requires a NoSQL table named "books" in your OCI Account.
+@NosqlTable(tableName = "books")
+public class Book {
+    @NosqlId(generated = true)
+    long id;
+    String title;
+    String author;
+    double price;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
+    public double getPrice() {
+        return price;
+    }
+
+    public void setPrice(double price) {
+        this.price = price;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Book book)) return false;
+
+        return getId() == book.getId() && Double.compare(getPrice(), book.getPrice()) == 0 && getTitle().equals(book.getTitle()) && getAuthor().equals(book.getAuthor());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Long.hashCode(getId());
+        result = 31 * result + getTitle().hashCode();
+        result = 31 * result + getAuthor().hashCode();
+        result = 31 * result + Double.hashCode(getPrice());
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Book{" +
+                "id=" + id +
+                ", title='" + title + '\'' +
+                ", author='" + author + '\'' +
+                ", price=" + price +
+                '}';
+    }
+}

--- a/spring-cloud-oci/spring-cloud-oci-samples/spring-cloud-oci-nosql-sample/src/main/java/com/oracle/cloud/spring/sample/nosql/springcloudnosqlsample/BookController.java
+++ b/spring-cloud-oci/spring-cloud-oci-samples/spring-cloud-oci-nosql-sample/src/main/java/com/oracle/cloud/spring/sample/nosql/springcloudnosqlsample/BookController.java
@@ -1,0 +1,64 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+package com.oracle.cloud.spring.sample.nosql.springcloudnosqlsample;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/books")
+public class BookController {
+    private final BookRepository bookRepository;
+
+    public BookController(BookRepository bookRepository) {
+        this.bookRepository = bookRepository;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<Book>> getAllBooks(@RequestParam(name = "title", required = false) String title,
+                                                  @RequestParam(name = "author", required = false) String author) {
+        List<Book> books = new ArrayList<>();
+        if (StringUtils.hasText(title)) {
+            bookRepository.findByTitle(title).forEach(books::add);
+        } else if (StringUtils.hasText(author)) {
+            bookRepository.findByAuthor(author).forEach(books::add);
+        } else {
+            bookRepository.findAll().forEach(books::add);
+        }
+
+        return ResponseEntity.ok(books);
+    }
+
+    @PostMapping
+    public ResponseEntity<Book> addBook(@RequestBody Book book) {
+        Book created = bookRepository.save(book);
+        return new ResponseEntity<>(created, HttpStatusCode.valueOf(201));
+    }
+
+    @PutMapping
+    public ResponseEntity<Book> updateBook(@RequestBody Book book) {
+        if (book.getId() < 1) {
+            return ResponseEntity.badRequest().build();
+        }
+        return addBook(bookRepository.save(book));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteBook(@PathVariable(name = "id") Long id) {
+        bookRepository.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/spring-cloud-oci/spring-cloud-oci-samples/spring-cloud-oci-nosql-sample/src/main/java/com/oracle/cloud/spring/sample/nosql/springcloudnosqlsample/BookRepository.java
+++ b/spring-cloud-oci/spring-cloud-oci-samples/spring-cloud-oci-nosql-sample/src/main/java/com/oracle/cloud/spring/sample/nosql/springcloudnosqlsample/BookRepository.java
@@ -1,0 +1,10 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+package com.oracle.cloud.spring.sample.nosql.springcloudnosqlsample;
+
+import com.oracle.nosql.spring.data.repository.NosqlRepository;
+
+public interface BookRepository extends NosqlRepository<Book, Long> {
+    Iterable<Book> findByAuthor(String author);
+    Iterable<Book> findByTitle(String title);
+}

--- a/spring-cloud-oci/spring-cloud-oci-samples/spring-cloud-oci-nosql-sample/src/main/java/com/oracle/cloud/spring/sample/nosql/springcloudnosqlsample/SpringCloudOciNoSQLSampleApplication.java
+++ b/spring-cloud-oci/spring-cloud-oci-samples/spring-cloud-oci-nosql-sample/src/main/java/com/oracle/cloud/spring/sample/nosql/springcloudnosqlsample/SpringCloudOciNoSQLSampleApplication.java
@@ -1,0 +1,16 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+package com.oracle.cloud.spring.sample.nosql.springcloudnosqlsample;
+
+import com.oracle.nosql.spring.data.config.AbstractNosqlConfiguration;
+import com.oracle.nosql.spring.data.repository.config.EnableNosqlRepositories;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+@EnableNosqlRepositories
+public class SpringCloudOciNoSQLSampleApplication extends AbstractNosqlConfiguration {
+    public static void main(String[] args) {
+        SpringApplication.run(SpringCloudOciNoSQLSampleApplication.class, args);
+    }
+}

--- a/spring-cloud-oci/spring-cloud-oci-samples/spring-cloud-oci-nosql-sample/src/main/resources/application.yaml
+++ b/spring-cloud-oci/spring-cloud-oci-samples/spring-cloud-oci-nosql-sample/src/main/resources/application.yaml
@@ -1,0 +1,7 @@
+spring:
+  cloud:
+    oci:
+      config:
+        type: file
+      region:
+        static: us-ashburn-1

--- a/spring-cloud-oci/spring-cloud-oci-samples/spring-cloud-oci-nosql-sample/src/test/java/com/oracle/cloud/spring/sample/nosql/springcloudnosqlsample/NoSQLSampleApplicationIT.java
+++ b/spring-cloud-oci/spring-cloud-oci-samples/spring-cloud-oci-nosql-sample/src/test/java/com/oracle/cloud/spring/sample/nosql/springcloudnosqlsample/NoSQLSampleApplicationIT.java
@@ -1,0 +1,67 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+package com.oracle.cloud.spring.sample.nosql.springcloudnosqlsample;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class NoSQLSampleApplicationIT {
+    @Autowired
+    private BookController bookController;
+
+    @Autowired
+    BookRepository bookRepository;
+
+    @Test
+    void bookControllerTest() {
+        // clear the book database before running the test
+        bookRepository.deleteAll();
+        // Create three Book objects
+        Book book1 = new Book();
+        book1.setTitle("To Kill a Mockingbird");
+        book1.setAuthor("Harper Lee");
+        book1.setPrice(12.99);
+
+        Book book2 = new Book();
+        book2.setTitle("1984");
+        book2.setAuthor("George Orwell");
+        book2.setPrice(10.99);
+
+        Book book3 = new Book();
+        book3.setTitle("Animal Farm");
+        book3.setAuthor("George Orwell");  // Same author as book2
+        book3.setPrice(9.99);
+
+        Book created1 = bookController.addBook(book1).getBody();
+        Book created2 = bookController.addBook(book2).getBody();
+        Book created3 = bookController.addBook(book3).getBody();
+
+        // Query books based on author
+        List<Book> georgeOrwellBooks = bookController.getAllBooks(null, "George Orwell").getBody();
+        assertThat(georgeOrwellBooks).hasSize(2);
+
+        // Query books based on title
+        List<Book> titleQueryBooks = bookController.getAllBooks("To Kill a Mockingbird", null).getBody();
+        assertThat(titleQueryBooks).hasSize(1);
+        assertThat(titleQueryBooks.get(0)).isEqualTo(created1);
+
+        // Update book
+        assertThat(created3).isNotNull();
+        created3.setPrice(25.00);
+        Book updated3 = bookController.updateBook(created3).getBody();
+        assertThat(updated3).isNotNull();
+        assertThat(updated3.getPrice()).isEqualTo(25.0);
+
+        // Delete book and verify it's gone
+        assertThat(created2).isNotNull();
+        bookController.deleteBook(created2.getId());
+        List<Book> title1984Books = bookController.getAllBooks("1984", null).getBody();
+        assertThat(title1984Books).hasSize(0);
+    }
+}

--- a/spring-cloud-oci/spring-cloud-oci-starters/pom.xml
+++ b/spring-cloud-oci/spring-cloud-oci-starters/pom.xml
@@ -59,6 +59,7 @@ Licensed under the Universal Permissive License v 1.0 as shown at https://oss.or
         <module>spring-cloud-oci-starter-queue</module>
         <module>spring-cloud-oci-starter-function</module>
         <module>spring-cloud-oci-starter-email</module>
+        <module>spring-cloud-oci-starter-nosql</module>
     </modules>
 
 </project>

--- a/spring-cloud-oci/spring-cloud-oci-starters/spring-cloud-oci-starter-nosql/pom.xml
+++ b/spring-cloud-oci/spring-cloud-oci-starters/spring-cloud-oci-starter-nosql/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2024, Oracle and/or its affiliates.
+Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<artifactId>spring-cloud-oci-starters</artifactId>
+		<groupId>com.oracle.cloud.spring</groupId>
+		<version>1.3.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>spring-cloud-oci-starter-nosql</artifactId>
+	<name>Spring Cloud Oracle NoSQL Starter Module</name>
+	<description>Spring Cloud Oracle NoSQL Starter Module</description>
+	<url>https://github.com/oracle/spring-cloud-oci/#spring-cloud-oci-documentation</url>
+
+	<organization>
+		<name>Oracle America, Inc.</name>
+		<url>https://www.oracle.com</url>
+	</organization>
+
+	<developers>
+		<developer>
+			<name>Oracle</name>
+			<email>obaas_ww at oracle.com</email>
+			<organization>Oracle America, Inc.</organization>
+			<organizationUrl>https://www.oracle.com</organizationUrl>
+		</developer>
+	</developers>
+
+	<licenses>
+		<license>
+			<name>The Universal Permissive License (UPL), Version 1.0</name>
+			<url>https://oss.oracle.com/licenses/upl/</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+
+	<scm>
+		<url>https://github.com/oracle/spring-cloud-oracle</url>
+		<connection>scm:git:https://github.com/oracle/spring-cloud-oracle.git</connection>
+		<developerConnection>scm:git:git@github.com:oracle/spring-cloud-oracle.git</developerConnection>
+	</scm>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.oracle.cloud.spring</groupId>
+			<artifactId>spring-cloud-oci-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.oracle.nosql.sdk</groupId>
+			<artifactId>spring-data-oracle-nosql</artifactId>
+		</dependency>
+	</dependencies>
+
+</project>


### PR DESCRIPTION
A Spring starter for Oracle NoSQL Spring SDK.
Autoconfiguration for Oracle NoSQL Spring SDK: configure and provide a NosqlDBConfig bean in the same style we do for other OCI services.